### PR TITLE
Apply filters to notifications already in the shade

### DIFF
--- a/app/src/main/java/co/adityarajput/notifilter/services/NotificationListener.kt
+++ b/app/src/main/java/co/adityarajput/notifilter/services/NotificationListener.kt
@@ -168,12 +168,37 @@ class NotificationListener : NotificationListenerService() {
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification) {
+        processNotification(sbn)
+    }
+
+    /**
+     * Runs filters against notifications that are already present in the shade.
+     * Returns the number of notifications that matched a filter.
+     */
+    suspend fun applyFiltersToActiveNotifications(): Int = withContext(Dispatchers.Default) {
+        val active = try {
+            activeNotifications
+        } catch (e: Throwable) {
+            Logger.e("NotificationListener", "Failed to read active notifications", e)
+            return@withContext 0
+        }
+
+        Logger.i("NotificationListener", "Applying filters to ${active.size} active notifications")
+
+        active.count { processNotification(it) }
+    }
+
+    /**
+     * Handles a single notification: picks a matching filter and executes its action.
+     * Returns `true` if a filter matched.
+     */
+    private fun processNotification(sbn: StatusBarNotification): Boolean {
         if (sbn.notification.flags and FLAG_GROUP_SUMMARY != 0) {
             Logger.d(
                 "NotificationListener",
                 "Ignoring group summary notification $sbn",
             )
-            return
+            return false
         }
 
         Logger.d(
@@ -189,7 +214,7 @@ class NotificationListener : NotificationListenerService() {
                     && it.enabled
                     && it.schedule.includesNow()
                     && it.matchesTextOf(notification)
-        }.minByOrNull { it.priority } ?: return
+        }.minByOrNull { it.priority } ?: return false
 
         Logger.i("NotificationListener", "Matched $filter")
 
@@ -201,7 +226,7 @@ class NotificationListener : NotificationListenerService() {
                     intents.launchMain()
                 } catch (e: Exception) {
                     Logger.e("NotificationListener", "Failed to tap notification", e)
-                    return
+                    return false
                 }
 
             is Action.TAP_BUTTON ->
@@ -211,7 +236,7 @@ class NotificationListener : NotificationListenerService() {
                     }?.value?.send()
                 } catch (e: Exception) {
                     Logger.e("NotificationListener", "Failed to tap button", e)
-                    return
+                    return false
                 }
 
             is Action.BATCH -> {
@@ -231,7 +256,7 @@ class NotificationListener : NotificationListenerService() {
                 } else if (notifications.any { it.data == notification.data }) {
                     // TODO: The above condition does not use the updated `notification.matches(other, delay)` check.
                     Logger.d("NotificationListener", "Already batched")
-                    return
+                    return false
                 } else {
                     snoozeNotification(
                         sbn.key,
@@ -259,7 +284,7 @@ class NotificationListener : NotificationListenerService() {
                     Logger.d("NotificationListener", "Less than 1 second of delay")
                 } else if (notifications.any { notification.matches(it, delay) }) {
                     Logger.d("NotificationListener", "Already delayed")
-                    return
+                    return false
                 } else {
                     snoozeNotification(sbn.key, delay)
                 }
@@ -369,6 +394,8 @@ class NotificationListener : NotificationListenerService() {
             notifications = repository.notifications().first()
             Logger.d("NotificationListener", "Notifications updated: $notifications")
         }
+
+        return true
     }
 
     fun dismissNotification(key: String, isClearable: Boolean) {

--- a/app/src/main/java/co/adityarajput/notifilter/views/screens/FiltersScreen.kt
+++ b/app/src/main/java/co/adityarajput/notifilter/views/screens/FiltersScreen.kt
@@ -1,6 +1,7 @@
 package co.adityarajput.notifilter.views.screens
 
 import android.content.Context.MODE_PRIVATE
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -43,6 +44,7 @@ import co.adityarajput.notifilter.views.components.ManageFilterDialog
 import co.adityarajput.notifilter.views.components.MissingPermissionsDialog
 import co.adityarajput.notifilter.views.components.Tile
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
 
@@ -54,7 +56,9 @@ fun FiltersScreen(
     viewModel: FiltersViewModel = viewModel(factory = Provider.Factory),
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val state = viewModel.state.collectAsState()
+    val appliedToNone = stringResource(R.string.applied_to_none)
     var hasPermissions by remember(state.value.filters) {
         mutableStateOf(context.isGranted(permissionsRequired(state.value.filters ?: listOf())))
     }
@@ -79,6 +83,36 @@ fun FiltersScreen(
     Scaffold(
         topBar = {
             AppBar(stringResource(R.string.app_name), false) {
+                // INFO: Runs filters against notifications already present in the shade
+                if (isListenerServiceInitialized)
+                    IconButton(
+                        {
+                            scope.launch {
+                                if (!NotificationListener.isServiceInitialized) return@launch
+
+                                val count = NotificationListener
+                                    .instance
+                                    .applyFiltersToActiveNotifications()
+
+                                Toast.makeText(
+                                    context,
+                                    if (count == 0) appliedToNone
+                                    else context.resources.getQuantityString(
+                                        R.plurals.applied_to_notifications,
+                                        count,
+                                        count,
+                                    ),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                            }
+                        },
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.filter_alt),
+                            stringResource(R.string.apply_filters_now),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
                 IconButton(goToSettingsScreen) {
                     Icon(
                         painterResource(R.drawable.settings),

--- a/app/src/main/res/drawable/filter_alt.xml
+++ b/app/src/main/res/drawable/filter_alt.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M440,800Q423,800 411.5,788.5Q400,777 400,760L400,520L168,224Q153,204 163.5,182Q174,160 200,160L760,160Q786,160 796.5,182Q807,204 792,224L560,520L560,760Q560,777 548.5,788.5Q537,800 520,800L440,800Z" />
+</vector>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -12,4 +12,8 @@
         <item quantity="one">%1$d hit</item>
         <item quantity="other">%1$d hits</item>
     </plurals>
+    <plurals name="applied_to_notifications">
+        <item quantity="one">Applied filters to %1$d notification</item>
+        <item quantity="other">Applied filters to %1$d notifications</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="history_disabled">history disabled</string>
     <string name="filter_disabled">filter disabled</string>
 
+    <string name="apply_filters_now">Apply filters to current notifications</string>
+    <string name="applied_to_none">No current notification matched your filters</string>
     <string name="adjust_priorities">Adjust priorities</string>
     <string name="move_up">Move up</string>
     <string name="move_down">Move down</string>


### PR DESCRIPTION
### Problem

Filters only ever run from `onNotificationPosted`, so a rule that is added or edited after a notification was posted never touches it. `getActiveNotifications()` is not called anywhere in the app, and `onListenerConnected` only writes to the log, so the usual workaround of toggling notification access does not help either: the OS is ready to hand over the active notifications, the app just never asks.

### Change

- extract the body of `onNotificationPosted` into `processNotification(sbn): Boolean`, which reports whether a filter matched;
- add `applyFiltersToActiveNotifications(): Int`, which walks `activeNotifications` and runs each one through that same handler;
- add a button to the filters screen app bar that triggers it and reports the count in a toast. It is only shown while the listener service is up.

### Notes

- actions are applied exactly as they are for incoming notifications, so nothing behaves differently depending on how the filter was run. For MUTE/ALERT/DEBOUNCE/DISTURB that is partly redundant since the sound has already played, but keeping a single code path seemed better than a second set of rules;
- the run is manual only. Doing it automatically on filter save, or from `onListenerConnected`, would clear the shade without the user asking for it.

Tested on a Moto G100 Pro (Android 16).
