### PR TITLE
Do not cache an empty app list

### DIFF
--- a/app/src/main/java/co/adityarajput/notifilter/data/Cache.kt
+++ b/app/src/main/java/co/adityarajput/notifilter/data/Cache.kt
@@ -35,11 +35,11 @@ object Cache {
     fun update(packageManager: PackageManager) {
         Logger.d("Cache", "Updating apps")
 
-        _allPackages = packageManager.getInstalledApplications(0)
+        val allPackages = packageManager.getInstalledApplications(0)
             .map { App(it.loadLabel(packageManager).toString(), it.packageName) }
             .sortedBy { it.name }
 
-        _visibleApps = packageManager.queryIntentActivities(
+        val visibleApps = packageManager.queryIntentActivities(
             Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_LAUNCHER),
             0,
         ).map {
@@ -49,7 +49,14 @@ object Cache {
             )
         }.sortedBy { it.name }
 
-        _cachedAt = System.currentTimeMillis()
+        _allPackages = allPackages
+        _visibleApps = visibleApps
+
+        // INFO: An empty result means the OS withheld the app list, e.g. because the user has
+        // not answered the permission prompt yet. Caching that would keep the filter form
+        // spinning for the whole timeout even after access is granted, so retry next time.
+        _cachedAt = if (allPackages.isEmpty()) 0L else System.currentTimeMillis()
+
         Logger.d("Cache", "Updated cache")
     }
 }


### PR DESCRIPTION
### Problem

`Cache.update` stamps `_cachedAt` unconditionally, so an empty result from the package manager is cached for the full ten minute timeout. On firmware that gates the installed app list behind a permission prompt the first call returns nothing, and the filter form then shows its loading spinner for ten minutes straight — even after the user grants access — because `allPackages` stays empty until the cache expires or the process is restarted.

Reproduced on a Moto G100 Pro (Chinese firmware, Android 16): the permission prompt only appeared on the second launch, and the spinner went away only after force-stopping the app.

### Change

Keep the empty result out of the cache, so the next call retries.
